### PR TITLE
Fix/clean-up the build for lmbench

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -18,8 +18,6 @@ done
 
 trap 'rm -f ${BASE}$$.s ${BASE}$$.c ${BASE}$$.o ${BASE}$$; exit 1' 1 2 15
 
-LDLIBS=-lm
-
 # check for HP-UX's ANSI compiler
 echo "main(int ac, char *av[]) { int i; }" > ${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}
@@ -33,7 +31,7 @@ else
 	fi
 fi
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
-	
+
 # check for IA64 HP-UX w/ HP's ANSI compiler; may need pointer swizzling
 arch=`echo $OS | awk -F- '{print $1;}'`
 if [ X$CC = "Xcc" -a X$arch = "Xia64" ]
@@ -48,7 +46,7 @@ then
 		&& CFLAGS="${CFLAGS} +DD64"
 	rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 fi
-	
+
 # check for bcopy (optionally set the SYS5 flag)
 echo "#include <string.h>" > ${BASE}$$.c
 echo "main() { char a[256], b[256]; bcopy(a, b, 256); }" >> ${BASE}$$.c
@@ -236,15 +234,20 @@ ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_BINDPROCESSOR=1";
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
-# check that we have sched_setaffinity
-echo "#include <stdlib.h>" > ${BASE}$$.c
-echo "#include <unistd.h>" >> ${BASE}$$.c
-echo "#include <sched.h>" >> ${BASE}$$.c
-echo "main() { unsigned long mask = 1; return sched_setaffinity(0, sizeof(unsigned long), &mask); }" >> ${BASE}$$.c
-${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
-	&& CFLAGS="${CFLAGS} -DHAVE_SCHED_SETAFFINITY=1";
-rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
-
+# check that we have sched_setaffinity and it builds cleanly
+cat << '_ACEOF' > ${BASE}$$.c
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <unistd.h>
+#include <sched.h>
+int main() {
+cpu_set_t set; CPU_ZERO(&set); CPU_SET(0, &set);
+if (sched_setaffinity(0, sizeof(set), &set) == -1) exit(EXIT_FAILURE); exit(EXIT_SUCCESS);
+}
+_ACEOF
+${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c ${LDLIBS} 1>${NULL} 2>${BASE}$$_err
+test -s ${BASE}$$_err || CFLAGS="${CFLAGS} -DHAVE_SCHED_SETAFFINITY=1"
+rm -f ${BASE}$$_err ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@
 # I finally know why Larry Wall's Makefile says "Grrrr".
 SHELL=/bin/sh
 
-CC=`../scripts/compiler`
+CC=x86_64-intelaxxia-linux-gcc
 MAKE=`../scripts/make`
 AR=ar
 ARCREATE=cr

--- a/src/bw_tcp.c
+++ b/src/bw_tcp.c
@@ -60,7 +60,7 @@ main(int ac, char **av)
 		{
 			int	conn;
 			conn = tcp_connect(optarg, TCP_DATA, SOCKOPT_NONE);
-			write(conn, "0", 1);
+			(void) !write(conn, "0", 1);
 			exit(0);
 		}
 		case 'm':

--- a/src/bw_unix.c
+++ b/src/bw_unix.c
@@ -97,7 +97,7 @@ reader(iter_t iterations, void* cookie)
 	size_t	todo = state->bytes;
 
 	while (iterations-- > 0) {
-		write(state->control[1], &todo, sizeof(todo));
+		(void) !write(state->control[1], &todo, sizeof(todo));
 		for (done = 0; done < todo; done += n) {
 			if ((n = read(state->pipes[0], state->buf, state->xfer)) <= 0) {
 				/* error! */
@@ -114,7 +114,7 @@ writer(int controlfd, int writefd, char* buf, void* cookie)
 	struct _state* state = (struct _state*)cookie;
 
 	for ( ;; ) {
-		read(controlfd, &todo, sizeof(todo));
+		(void) !read(controlfd, &todo, sizeof(todo));
 		for (done = 0; done < todo; done += n) {
 #ifdef TOUCH
 			touch(buf, XFERSIZE);

--- a/src/hello.c
+++ b/src/hello.c
@@ -3,6 +3,6 @@
 int
 main()
 {
-	write(1, "Hello world\n", 12);
+	(void) !write(1, "Hello world\n", 12);
 	return (0);
 }

--- a/src/lat_connect.c
+++ b/src/lat_connect.c
@@ -52,7 +52,7 @@ main(int ac, char **av)
 			int sock = tcp_connect(av[optind],
 					       TCP_CONNECT,
 					       SOCKOPT_NONE);
-			write(sock, "0", 1);
+			(void) !write(sock, "0", 1);
 			close(sock);
 			exit(0);
 		}

--- a/src/lat_fcntl.c
+++ b/src/lat_fcntl.c
@@ -120,8 +120,8 @@ initialize(iter_t iterations, void* cookie)
 	}
 	unlink(state->filename1);
 	unlink(state->filename2);
-	write(state->fd1, buf, sizeof(buf));
-	write(state->fd2, buf, sizeof(buf));
+	(void) !write(state->fd1, buf, sizeof(buf));
+	(void) !write(state->fd2, buf, sizeof(buf));
 	lock.l_type = F_WRLCK;
 	lock.l_whence = 0;
 	lock.l_start = 0;

--- a/src/lat_fs.c
+++ b/src/lat_fs.c
@@ -117,7 +117,7 @@ mkfile(char *name, size_t size)
 
 	while (size > 0) {
 		chunk = ((size > (128*1024)) ? (128*1024) : size);
-		write(fd, buf, chunk);
+		(void) !write(fd, buf, chunk);
 		size -= chunk;
 	}
 	close(fd);

--- a/src/lat_http.c
+++ b/src/lat_http.c
@@ -29,11 +29,11 @@ http(char *server, char *file, int prog)
 	if (debug) {
 		printf(buf);
 	}
-	write(sock, buf, strlen(buf));
+	(void) !write(sock, buf, strlen(buf));
 	while ((n = read(sock, buf, XFERSIZE)) > 0) {
 		b += n;
 		if (echo) {
-			write(1, buf, n);
+			(void) !write(1, buf, n);
 		}
 	}
 	close(sock);
@@ -49,7 +49,7 @@ killhttp(char *server, int prog)
 	int     sock;
 
 	sock = tcp_connect(server, prog, SOCKOPT_REUSE);
-	write(sock, "EXIT", 4);
+	(void) !write(sock, "EXIT", 4);
 	close(sock);
 }
 

--- a/src/lat_proc.c
+++ b/src/lat_proc.c
@@ -111,7 +111,7 @@ do_shell(iter_t iterations, void* cookie)
 		case 0:	/* child */
 			handle_scheduler(benchmp_childid(), 1, 1);
 			close(1);
-			execlp("/bin/sh", "sh", "-c", PROG, 0);
+			execlp("/bin/sh", "sh", "-c", PROG, (char *)0);
 			exit(1);
 
 		default:

--- a/src/lat_select.c
+++ b/src/lat_select.c
@@ -131,7 +131,7 @@ server(void* cookie)
 		/* child server process */
 		while (pid == getppid()) {
 			int newsock = tcp_accept(state->sock, SOCKOPT_NONE);
-			read(newsock, &state->fid, 1);
+			(void) !read(newsock, &state->fid, 1);
 			close(newsock);
 		}
 		exit(0);

--- a/src/lat_tcp.c
+++ b/src/lat_tcp.c
@@ -100,7 +100,7 @@ init(iter_t iterations, void* cookie)
 	state->sock = tcp_connect(state->server, TCP_XACT, SOCKOPT_NONE);
 	state->buf = malloc(state->msize);
 
-	write(state->sock, &msize, sizeof(int));
+	(void) !write(state->sock, &msize, sizeof(int));
 }
 
 void
@@ -121,8 +121,8 @@ doclient(iter_t iterations, void* cookie)
 	int 	sock   = state->sock;
 
 	while (iterations-- > 0) {
-		write(sock, state->buf, state->msize);
-		read(sock, state->buf, state->msize);
+		(void) !write(sock, state->buf, state->msize);
+		(void) !read(sock, state->buf, state->msize);
 	}
 }
 
@@ -161,7 +161,7 @@ doserver(int sock)
 		char*   buf = (char*)malloc(msize);
 
 		for (n = 0; read(sock, buf, msize) > 0; n++) {
-			write(sock, buf, msize);
+			(void) !write(sock, buf, msize);
 		}
 		free(buf);
 	} else {

--- a/src/lat_unix.c
+++ b/src/lat_unix.c
@@ -94,7 +94,7 @@ initialize(iter_t iterations, void* cookie)
 	/* Child sits and ping-pongs packets back to parent */
 	signal(SIGTERM, exit);
 	while (read(pState->sv[0], pState->buf, pState->msize) == pState->msize) {
-		write(pState->sv[0], pState->buf, pState->msize);
+		(void) !write(pState->sv[0], pState->buf, pState->msize);
 	}
 	exit(0);
 }

--- a/src/lat_unix_connect.c
+++ b/src/lat_unix_connect.c
@@ -47,7 +47,7 @@ int main(int ac, char **av)
 		}
 		if (!strcmp(av[1], "-S")) {
 			int sock = unix_connect(CONNAME);
-			write(sock, "0", 1);
+			(void) !write(sock, "0", 1);
 			close(sock);
 			exit(0);
 		}
@@ -92,7 +92,7 @@ void server_main(void)
 	for (;;) {
 		newsock = unix_accept(sock);
 		c = 0;
-		read(newsock, &c, 1);
+		(void) !read(newsock, &c, 1);
 		if (c && c == '0') {
 			unix_done(sock, CONNAME);
 			exit(0);

--- a/src/lib_debug.c
+++ b/src/lib_debug.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "bench.h"
 #include "lib_debug.h"
 

--- a/src/lib_sched.c
+++ b/src/lib_sched.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include "bench.h"
 
 /* #define _DEBUG */
@@ -204,7 +205,8 @@ sched_pin(int cpu)
 		sz = 1 + (2 * sched_ncpus()) / (8 * sizeof(unsigned long));
 		mask = (unsigned long*)malloc(sz * sizeof(unsigned long));
 		cpumask = (unsigned long*)malloc(sz * sizeof(unsigned long));
-		retval = sched_getaffinity(0, sz * sizeof(unsigned long), cpumask);
+		retval = sched_getaffinity(0, sz * sizeof(unsigned long),
+					(cpu_set_t *) cpumask);
 		if (retval < 0) perror("sched_getaffinity:");
 		if (retval < 0) return retval;
 
@@ -228,7 +230,8 @@ sched_pin(int cpu)
 			j++;
 		}
 	}
-	retval = sched_setaffinity(0, sz * sizeof(unsigned long), mask);
+	retval = sched_setaffinity(0, sz * sizeof(unsigned long),
+			(const cpu_set_t *) mask);
 	if (retval < 0) perror("sched_setaffinity:");
 #ifdef _DEBUG
 	fprintf(stderr, "sched_pin(%d): pid=%d, returning %d\n", cpu, (int)getpid(), retval);

--- a/src/lib_timing.c
+++ b/src/lib_timing.c
@@ -401,7 +401,7 @@ benchmp_parent(	int response,
 	}
 
 	/* send 'start' signal */
-	write(start_signal, signals, parallel * sizeof(char));
+	(void) !write(start_signal, signals, parallel * sizeof(char));
 
 	/* Collect 'done' signals */
 	for (i = 0; i < parallel * sizeof(char); i += bytes_read) {
@@ -446,7 +446,7 @@ benchmp_parent(	int response,
 		FD_ZERO(&fds_error);
 
 		/* tell one child to report its results */
-		write(result_signal, buf, sizeof(char));
+		(void) !write(result_signal, buf, sizeof(char));
 
 		for (; n > 0; n -= bytes_read, buf += bytes_read) {
 			bytes_read = 0;
@@ -487,7 +487,7 @@ benchmp_parent(	int response,
 	signal(SIGCHLD, SIG_DFL);
 	
 	/* send 'exit' signals */
-	write(exit_signal, results, parallel * sizeof(char));
+	(void) !write(exit_signal, results, parallel * sizeof(char));
 
 	/* Compute median time; iterations is constant! */
 	set_results(merged_results);
@@ -700,13 +700,13 @@ benchmp_interval(void* _state)
 		       NULL, &timeout);
 		if (FD_ISSET(state->start_signal, &fds)) {
 			state->state = timing_interval;
-			read(state->start_signal, &c, sizeof(char));
+			(void) !read(state->start_signal, &c, sizeof(char));
 			iterations = state->iterations;
 		}
 		if (state->need_warmup) {
 			state->need_warmup = 0;
 			/* send 'ready' */
-			write(state->response, &c, sizeof(char));
+			(void) !write(state->response, &c, sizeof(char));
 		}
 		break;
 	case timing_interval:
@@ -736,7 +736,7 @@ benchmp_interval(void* _state)
 		state->iterations = iterations;
 		if (state->state == cooldown) {
 			/* send 'done' */
-			write(state->response, (void*)&c, sizeof(char));
+			(void) !write(state->response, (void*)&c, sizeof(char));
 			iterations = state->iterations_batch;
 		}
 		break;
@@ -751,8 +751,8 @@ benchmp_interval(void* _state)
 			 * the parent to tell us to send our results back.
 			 * From this point on, we will do no more "work".
 			 */
-			read(state->result_signal, (void*)&c, sizeof(char));
-			write(state->response, (void*)get_results(), state->r_size);
+			(void) !read(state->result_signal, (void*)&c, sizeof(char));
+			(void) !write(state->response, (void*)get_results(), state->r_size);
 			if (state->cleanup) {
 				if (benchmp_sigchld_handler == SIG_DFL)
 					signal(SIGCHLD, SIG_DFL);
@@ -760,7 +760,7 @@ benchmp_interval(void* _state)
 			}
 
 			/* Now wait for signal to exit */
-			read(state->exit_signal, (void*)&c, sizeof(char));
+			(void) !read(state->exit_signal, (void*)&c, sizeof(char));
 			exit(0);
 		}
 	};

--- a/src/memsize.c
+++ b/src/memsize.c
@@ -137,7 +137,7 @@ test_malloc(size_t size)
 		close(fid[0]);
 		p = malloc(size);
 		result = (p ? 1 : 0);
-		write(fid[1], &result, sizeof(int));
+		(void) !write(fid[1], &result, sizeof(int));
 		close(fid[1]);
 		if (p) free(p);
 		exit(0);


### PR DESCRIPTION
This is the heads-up that meta-oe of Yocto is planning on integrating a couple
of changes to lmbench.

These changes can be wrapped up around fixing/cleaning up as follows:
- if lmbench doesn't use a return from a function attributed to warn_unused_result
  supress the warning/s
- fix buffer overflow
- define feature_test_macro _GNU_SOURCE compiling in sched_{get,set}affinity()
- go strict for a pre-build check if sched_{get,set}affinity() from glibc builds
  cleanly. If it is not compile it out.

Please find the original discussion on the changes at meta-oe
http://lists.openembedded.org/pipermail/openembedded-devel/2019-October/202206.html

I have tested these changes against this repo and they build just fine.
The compiler warns though about the changes which already are in the meta-oe and
are not part of this commit.

Signed-off-by: Marek Bykowski <marek.bykowski@gmail.com>
Reviewed-off-by: Marcin Lapaj <marcin.lapaj@tieto.com>