### PR TITLE
Update getsummary

### DIFF
--- a/scripts/getsummary
+++ b/scripts/getsummary
@@ -327,7 +327,7 @@ foreach $file (@ARGV) {
 			    	last if /^\s*$/ || /^Memory/;
 			}
 		}
-		if (/size=16/) {
+		if (/size=16k/) {
 			while (<FD>) {
 				if (/^2 /) {
 					@_ = split; push(@lat_ctx16_2, $_[1]);


### PR DESCRIPTION
When the getsummary file is not updated, some values of our test report will be lost. After the update, this problem has been solved.
When there is no update getsummary file, all items in "Processor, Processes",  "Basic integer operations",  "Basic uint64 operations", "Basic float operations" and "Basic double operations " are empty except for items "Host" and "OS" .
After updating the file, you will get a complete test report without missing values.