### PR TITLE
lat_fs: get tmpdir from the last input parameter

### DIFF
--- a/src/lat_fs.c
+++ b/src/lat_fs.c
@@ -69,7 +69,7 @@ main(int ac, char **av)
 		lmbench_usage(ac, av, usage);
 	}
 	if (optind == ac - 1) {
-		state.tmpdir = av[1];
+		state.tmpdir = av[optind];
 	}
 
 	if (state.size) {


### PR DESCRIPTION
The usage of lat_fs is:
`lat_fs [-s <file size>] [-n <max files per dir>] [-P <parallelism>] [-W <warmup>] [-N <repetitions>] [<dir>]`
, it is clear `dir` is the last parameter. While handling the `state.tmpdir`,
current code is reading from the first parameter. If we pass command like,
`lat_fs -P 1 /usr/tmp`, `tmpdir` will be `-P`, which is invalid path and
tempnam() call falls back to /tmp, not the expected dir `/usr/tmp`.