### PR TITLE
check for&use libtirpc, support large cpuset_t

### DIFF
--- a/src/lib_sched.c
+++ b/src/lib_sched.c
@@ -202,6 +202,7 @@ sched_pin(int cpu)
 	
 	if (cpumask == NULL) {
 		sz = 1 + (2 * sched_ncpus()) / (8 * sizeof(unsigned long));
+		if (sz<sizeof(cpu_set_t)/sizeof(unsigned long)) sz = sizeof(cpu_set_t)/sizeof(unsigned long);
 		mask = (unsigned long*)malloc(sz * sizeof(unsigned long));
 		cpumask = (unsigned long*)malloc(sz * sizeof(unsigned long));
 		retval = sched_getaffinity(0, sz * sizeof(unsigned long), cpumask);


### PR DESCRIPTION
Recent debian distributions (for some really lax definition of "recent") will not compile without libtirpc.

Contemporary cpuset_t can be larger than the minimum required to fit available cpus.