### PR TITLE
Fix build with tirpc

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -18,7 +18,7 @@ done
 
 trap 'rm -f ${BASE}$$.s ${BASE}$$.c ${BASE}$$.o ${BASE}$$; exit 1' 1 2 15
 
-LDLIBS=-lm
+LDLIBS="-lm -ltirpc"
 
 # check for HP-UX's ANSI compiler
 echo "main(int ac, char *av[]) { int i; }" > ${BASE}$$.c


### PR DESCRIPTION
As we discussed at https://github.com/intel/lmbench/pull/26#issuecomment-3141588417, this fix is necessary to build `lmbench` with the `libtirpc-dev` package. With this patch, I have confirmed that `make build CPPFLAGS="-I /usr/include/tirpc"` succeeds.

My environment is as follows:
```
$ uname -a
Linux masumi 6.14.0-27-generic #27~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jul 22 17:38:49 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
$ apt list --installed 2>/dev/null | grep tirpc
libntirpc4.3t64/noble,now 4.3-3.1build2 amd64 [installed,auto-removable]
libtirpc-common/noble,noble,now 1.3.4+ds-1.1build1 all [installed,automatic]
libtirpc-dev/noble,now 1.3.4+ds-1.1build1 amd64 [installed]
libtirpc3t64/noble,now 1.3.4+ds-1.1build1 amd64 [installed,automatic]
```

Related links:
- https://github.com/intel/lmbench/pull/26#issuecomment-3141588417
- https://github.com/intel/lmbench/issues/21#issuecomment-2505306060