### PR TITLE
Fix integer overflow in lat_pagefault.c

### DIFF
--- a/src/lat_pagefault.c
+++ b/src/lat_pagefault.c
@@ -18,8 +18,8 @@ char	*id = "$Id$\n";
 
 typedef struct _state {
 	int fd;
-	int size;
-	int npages;
+	size_t size;
+	long npages;
 	int clone;
 	char* file;
 	char* where;


### PR DESCRIPTION
This patch addresses an issue in the lat_pagefault test where the test would fail when working with files of 2GB or larger. By default, `make results` creates a test file sized at 80% of the current system's available memory, which makes this test prone to failure on modern systems with large memory capacities.

The root cause is that the `state_t` structure uses `int` type for `size` and `npages` fields, which can overflow when dealing with large files. This patch changes these fields to properly handle larger file sizes.

Changes made:

Changed `size` in state_t from `int` to `size_t` type
Changed `npages` in state_t from `int` to `long` type