### PR TITLE
src/bench.h: include string.h

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -27,6 +27,7 @@ typedef unsigned char bool_t;
 #ifndef WIN32
 #include        <strings.h>
 #endif
+#include        <string.h>
 #include        <sys/types.h>
 #ifndef WIN32
 #include        <sys/mman.h>


### PR DESCRIPTION
Fixes build error with newer gcc, detected by buildroot autobuilders:
https://autobuild.buildroot.net/results/189/189219853fbe1b7daf0aaad29279858c6e60507b//build-end.log
```
lib_unix.c: In function 'unix_server':
lib_unix.c:29:9: error: implicit declaration of function 'strcpy' [-Wimplicit-function-declaration]
   29 |         strcpy(s.sun_path, path);
      |         ^~~~~~
lib_unix.c:10:1: note: include '<string.h>' or provide a declaration of 'strcpy'
```
