### PR TITLE
scripts/build: make it possible to set LDLIBS

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -18,7 +18,7 @@ done
 
 trap 'rm -f ${BASE}$$.s ${BASE}$$.c ${BASE}$$.o ${BASE}$$; exit 1' 1 2 15
 
-LDLIBS="-lm"
+LDLIBS="${LDLIBS} -lm"
 
 # check for HP-UX's ANSI compiler
 echo "main(int ac, char *av[]) { int i; }" > ${BASE}$$.c


### PR DESCRIPTION
LDLIBS is currently unconditionnally set to '-lm', but doesn't allow the user to provide additional libraries to link with.

This patch is used by buildroot:
https://gitlab.com/buildroot.org/buildroot/-/commit/80f25d47060dea19b8f3b5fd84b6238375c54729