### PR TITLE
Fix garbage pointer for lat_rpc -S localhost

### DIFF
--- a/src/lat_rpc.c
+++ b/src/lat_rpc.c
@@ -105,6 +105,7 @@ main(int ac, char **av)
 	char	*usage = "-s\n OR [-p <tcp|udp>] [-P parallel] [-W <warmup>] [-N <repetitions>] serverhost\n OR -S serverhost\n";
 
 	state.msize = 1;
+	state.server = NULL;
 
 	while (( c = getopt(ac, av, "sS:m:p:P:W:N:")) != EOF) {
 		switch(c) {


### PR DESCRIPTION
This patch is used by buildroot:
https://gitlab.com/buildroot.org/buildroot/-/commit/e1137c06a0db69ba0724f22cd09ea92b82ac59a6