### PR TITLE
Results stats

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -165,6 +165,7 @@ int	gettimeofday(struct timeval *tv, struct timezone *tz);
 typedef struct {
 	uint64 u;
 	uint64 n;
+	double udn;
 } value_t;
 
 typedef struct {
@@ -176,9 +177,11 @@ void    insertinit(result_t *r);
 void    insertsort(uint64, uint64, result_t *);
 void	save_median();
 void	save_minimum();
+void    save_avg_stddev();
 void	set_results(result_t *r);
 result_t* get_results();
-
+double  get_avg_time_per_iter();
+double  get_stddev_percent();
 
 #define	BENCHO(loop_body, overhead_body, enough) { 			\
 	int 		__i, __N;					\

--- a/src/bench.h
+++ b/src/bench.h
@@ -172,6 +172,14 @@ typedef struct {
 	int	N;
 	value_t	v[TRIES];
 } result_t;
+
+typedef struct {
+	uint64 time;
+	uint64 n;
+	double avg_time_per_iter;
+	double stddev;
+} stats_t;
+
 int	sizeof_result(int N);
 void    insertinit(result_t *r);
 void    insertsort(uint64, uint64, result_t *);
@@ -182,6 +190,9 @@ void	set_results(result_t *r);
 result_t* get_results();
 double  get_avg_time_per_iter();
 double  get_stddev_percent();
+void    record_stats(stats_t *stats);
+void    set_child_stats(stats_t *stats);
+stats_t* get_child_stats();
 
 #define	BENCHO(loop_body, overhead_body, enough) { 			\
 	int 		__i, __N;					\

--- a/src/bw_mem.c
+++ b/src/bw_mem.c
@@ -54,7 +54,7 @@ typedef struct _state {
 	size_t	N;
 } state_t;
 
-void	adjusted_bandwidth(uint64 t, uint64 b, uint64 iter, double ovrhd);
+void	adjusted_bandwidth(uint64 t, uint64 b, uint64 iter, int parallel, double ovrhd, double avg_time_per_iter, double stddev_pct, int verbose);
 
 int
 main(int ac, char **av)
@@ -62,14 +62,15 @@ main(int ac, char **av)
 	int	parallel = 1;
 	int	warmup = 0;
 	int	repetitions = TRIES;
+	int	verbose = 0;
 	size_t	nbytes;
 	state_t	state;
 	int	c;
-	char	*usage = "[-P <parallelism>] [-W <warmup>] [-N <repetitions>] <size> what [conflict]\nwhat: rd wr rdwr cp fwr frd fcp bzero bcopy\n<size> must be larger than 512";
+	char	*usage = "[-P <parallelism>] [-W <warmup>] [-N <repetitions>] [-v] <size> what [conflict]\nwhat: rd wr rdwr cp fwr frd fcp bzero bcopy\n<size> must be larger than 512";
 
 	state.overhead = 0;
 
-	while (( c = getopt(ac, av, "P:W:N:")) != EOF) {
+	while (( c = getopt(ac, av, "P:W:N:v")) != EOF) {
 		switch(c) {
 		case 'P':
 			parallel = atoi(optarg);
@@ -80,6 +81,9 @@ main(int ac, char **av)
 			break;
 		case 'N':
 			repetitions = atoi(optarg);
+			break;
+		case 'v':
+			verbose = 1;
 			break;
 		default:
 			lmbench_usage(ac, av, usage);
@@ -135,8 +139,8 @@ main(int ac, char **av)
 	} else {
 		lmbench_usage(ac, av, usage);
 	}
-	adjusted_bandwidth(gettime(), nbytes, 
-			   get_n() * parallel, state.overhead);
+	adjusted_bandwidth(gettime(), nbytes, get_n(), parallel, state.overhead,
+			   get_avg_time_per_iter(), get_stddev_percent(), verbose);
 	return(0);
 }
 
@@ -440,12 +444,14 @@ loop_bcopy(iter_t iterations, void *cookie)
  * Almost like bandwidth() in lib_timing.c, but we need to adjust
  * bandwidth based upon loop overhead.
  */
-void adjusted_bandwidth(uint64 time, uint64 bytes, uint64 iter, double overhd)
+void adjusted_bandwidth(uint64 time, uint64 bytes, uint64 iter, int parallel, double overhd, double avg_time_per_iter, double stddev_pct, int verbose)
 {
 #define MB	(1000. * 1000.)
 	extern FILE *ftiming;
+	iter = iter * parallel;
 	double secs = ((double)time / (double)iter - overhd) / 1000000.0;
 	double mb;
+	double avg_secs = (avg_time_per_iter / parallel - overhd) / 1000000.0;
 	
         mb = bytes / MB;
 
@@ -459,10 +465,18 @@ void adjusted_bandwidth(uint64 time, uint64 bytes, uint64 iter, double overhd)
 		(void) fprintf(ftiming, "%.2f ", mb);
 	}
 	if (mb / secs < 1.) {
-		(void) fprintf(ftiming, "%.6f\n", mb/secs);
+		(void) fprintf(ftiming, "%.6f", mb/secs);
 	} else {
-		(void) fprintf(ftiming, "%.2f\n", mb/secs);
+		(void) fprintf(ftiming, "%.2f", mb/secs);
 	}
+	if (verbose) {
+		if (mb / avg_secs < 1.) {
+			(void) fprintf(ftiming, " %.6f", mb/avg_secs);
+		} else {
+			(void) fprintf(ftiming, " %.2f", mb/avg_secs);
+		}
+		(void) fprintf(ftiming, " time_per_iter_stddev=%.2f%%", stddev_pct);
+	}
+	(void) fprintf(ftiming, "\n");
 }
-
 

--- a/src/bw_mem.c
+++ b/src/bw_mem.c
@@ -55,6 +55,7 @@ typedef struct _state {
 } state_t;
 
 void	adjusted_bandwidth(uint64 t, uint64 b, uint64 iter, int parallel, double ovrhd, double avg_time_per_iter, double stddev_pct, int verbose);
+void	print_child_bandwidth(uint64 bytes, int parallel, double overhd);
 
 int
 main(int ac, char **av)
@@ -141,6 +142,9 @@ main(int ac, char **av)
 	}
 	adjusted_bandwidth(gettime(), nbytes, get_n(), parallel, state.overhead,
 			   get_avg_time_per_iter(), get_stddev_percent(), verbose);
+	if (verbose) {
+		print_child_bandwidth(nbytes, parallel, state.overhead);
+	}
 	return(0);
 }
 
@@ -480,3 +484,21 @@ void adjusted_bandwidth(uint64 time, uint64 bytes, uint64 iter, int parallel, do
 	(void) fprintf(ftiming, "\n");
 }
 
+void print_child_bandwidth(uint64 bytes, int parallel, double overhd)
+{
+	extern FILE *ftiming;
+	stats_t *child_stats = get_child_stats();
+	int i;
+
+	if (!child_stats)
+		return;
+
+	if (!ftiming) ftiming = stderr;
+
+	for (i = 0; i < parallel; ++i) {
+		stats_t *stat = &child_stats[i];
+		(void) fprintf(ftiming, "child %d: ", i);
+		adjusted_bandwidth(stat->time, bytes, stat->n, 1, overhd,
+				   stat->avg_time_per_iter, stat->stddev, 1);
+	}
+}

--- a/src/bw_mem64.c
+++ b/src/bw_mem64.c
@@ -53,6 +53,7 @@ typedef struct _state {
 } state_t;
 
 void	adjusted_bandwidth(uint64 t, uint64 b, uint64 iter, int parallel, double ovrhd, double avg_time_per_iter, double stddev_pct, int verbose);
+void	print_child_bandwidth(uint64 bytes, int parallel, double overhd);
 
 int
 main(int ac, char **av)
@@ -139,6 +140,9 @@ main(int ac, char **av)
 	}
 	adjusted_bandwidth(gettime(), nbytes, get_n(), parallel, state.overhead,
 			   get_avg_time_per_iter(), get_stddev_percent(), verbose);
+	if (verbose) {
+		print_child_bandwidth(nbytes, parallel, state.overhead);
+	}
 	return(0);
 }
 
@@ -444,4 +448,23 @@ void adjusted_bandwidth(uint64 time, uint64 bytes, uint64 iter, int parallel, do
 		(void) fprintf(ftiming, " time_per_iter_stddev=%.2f%%", stddev_pct);
 	}
 	(void) fprintf(ftiming, "\n");
+}
+
+void print_child_bandwidth(uint64 bytes, int parallel, double overhd)
+{
+	extern FILE *ftiming;
+	stats_t *child_stats = get_child_stats();
+	int i;
+
+	if (!child_stats)
+		return;
+
+	if (!ftiming) ftiming = stderr;
+
+	for (i = 0; i < parallel; ++i) {
+		stats_t *stat = &child_stats[i];
+		(void) fprintf(ftiming, "child %d: ", i);
+		adjusted_bandwidth(stat->time, bytes, stat->n, 1, overhd,
+				   stat->avg_time_per_iter, stat->stddev, 1);
+	}
 }


### PR DESCRIPTION
Add results statistics (average/stddev%) for overall results and child process results.  Help to analyze the stability of the test results.