### PR TITLE
Fix main() declarations in build script for gcc compatibility

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -51,14 +51,14 @@ fi
 	
 # check for bcopy (optionally set the SYS5 flag)
 echo "#include <string.h>" > ${BASE}$$.c
-echo "main() { char a[256], b[256]; bcopy(a, b, 256); }" >> ${BASE}$$.c
+echo "int main() { char a[256], b[256]; bcopy(a, b, 256); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	|| CFLAGS="${CFLAGS} -DSYS5"
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 # check for valloc
 echo "#include <stdlib.h>" > ${BASE}$$.c
-echo "main() { char* buf = valloc(123); }" >> ${BASE}$$.c
+echo "int main() { char* buf = valloc(123); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	|| CFLAGS="${CFLAGS} -Dvalloc=malloc"
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -70,13 +70,13 @@ echo "#include <sys/resource.h>" >> ${BASE}$$.c
 echo "#ifndef RUSAGE_SELF" >> ${BASE}$$.c
 echo "#define RUSAGE_SELF 0" >> ${BASE}$$.c
 echo "#endif /* RUSAGE_SELF */" >> ${BASE}$$.c
-echo "main() { struct rusage ru; getrusage(RUSAGE_SELF, &ru); }" >> ${BASE}$$.c
+echo "int main() { struct rusage ru; getrusage(RUSAGE_SELF, &ru); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DRUSAGE"
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 # check for -lnsl
-echo "extern int pmap_getport(); main() { pmap_getport(); }" > ${BASE}$$.c
+echo "extern int pmap_getport(); int main() { pmap_getport(); }" > ${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
 	true;
 else
@@ -87,7 +87,7 @@ rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 
 # check for -lsocket
-echo "extern void* getservent(); main() { getservent(); }" > ${BASE}$$.c
+echo "extern void* getservent(); int main() { getservent(); }" > ${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
 	true;
 else
@@ -97,7 +97,7 @@ fi
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 # check for -lrt (solaris)
-echo "extern int nanosleep(); main() { nanosleep(); }" >${BASE}$$.c
+echo "extern int nanosleep(); int main() { nanosleep(); }" >${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
        true;
 else
@@ -107,7 +107,7 @@ fi
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 # check for -lrpc (cygwin/Windows)
-echo "extern int pmap_set(); main() { pmap_set(); }" >${BASE}$$.c
+echo "extern int pmap_set(); int main() { pmap_set(); }" >${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
        true;
 else
@@ -118,13 +118,13 @@ rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 # check for OSs that have S_IFFIFO instead of S_IFIFO
 echo "#include <sys/stat.h>" > ${BASE}$$.c
-echo "main() { return (S_IFIFO); }" >> ${BASE}$$.c
+echo "int main() { return (S_IFIFO); }" >> ${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
 	true;
 else
 	rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 	echo "#include <sys/stat.h>" > ${BASE}$$.c
-	echo "main() { return (S_IFFIFO); }" >> ${BASE}$$.c
+	echo "int main() { return (S_IFFIFO); }" >> ${BASE}$$.c
 	${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 		|| CFLAGS="${CFLAGS} -DS_IFIFO=S_IFFIFO"
 fi
@@ -133,7 +133,7 @@ rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 # check that we have uint
 echo "#include <stdlib.h>" > ${BASE}$$.c
 echo "#include <sys/types.h>" >> ${BASE}$$.c
-echo "main() { uint i = 0; return (i); }" >> ${BASE}$$.c
+echo "int main() { uint i = 0; return (i); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_uint=1";
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -143,7 +143,7 @@ HAVE_uint64=0
 echo "#include <stdlib.h>" > ${BASE}$$.c
 echo "#include <sys/types.h>" >> ${BASE}$$.c
 echo "#include <rpc/types.h>" >> ${BASE}$$.c
-echo "main() { uint64 i = 0; return (int)(i); }" >> ${BASE}$$.c
+echo "int main() { uint64 i = 0; return (int)(i); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_uint64=1" && HAVE_uint64=1;
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -152,7 +152,7 @@ rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 if [ ${HAVE_uint64} = 0 ]; then
     echo "#include <stdlib.h>" > ${BASE}$$.c
     echo "#include <sys/types.h>" >> ${BASE}$$.c
-    echo "main() { uint64_t i = 0; return (int)(i); }" >> ${BASE}$$.c
+    echo "int main() { uint64_t i = 0; return (int)(i); }" >> ${BASE}$$.c
     ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_uint64_t=1";
     rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -163,7 +163,7 @@ HAVE_int64=0
 echo "#include <stdlib.h>" > ${BASE}$$.c
 echo "#include <sys/types.h>" >> ${BASE}$$.c
 echo "#include <rpc/types.h>" >> ${BASE}$$.c
-echo "main() { int64 i = 0; return (int)(i); }" >> ${BASE}$$.c
+echo "int main() { int64 i = 0; return (int)(i); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_int64=1" && HAVE_int64=1;
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -172,7 +172,7 @@ rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 if [ ${HAVE_int64} = 0 ]; then
     echo "#include <stdlib.h>" > ${BASE}$$.c
     echo "#include <sys/types.h>" >> ${BASE}$$.c
-    echo "main() { int64_t i = 0; return (int)(i); }" >> ${BASE}$$.c
+    echo "int main() { int64_t i = 0; return (int)(i); }" >> ${BASE}$$.c
     ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_int64_t=1";
     rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -181,7 +181,7 @@ fi
 # check that we have drand48 and srand48
 HAVE_RANDOM=0
 echo "#include <stdlib.h>" > ${BASE}$$.c
-echo "main() { srand48(973); return (int)(1.0E9 * drand48()); }" >> ${BASE}$$.c
+echo "int main() { srand48(973); return (int)(1.0E9 * drand48()); }" >> ${BASE}$$.c
 if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
 	CFLAGS="${CFLAGS} -DHAVE_DRAND48"
 	HAVE_RANDOM=1
@@ -190,7 +190,7 @@ rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 if [ ${HAVE_RANDOM} -eq 0 ]; then
     echo "#include <stdlib.h>" > ${BASE}$$.c
-    echo "main() { srand(973); return (10 * rand()) / RAND_MAX; }" >> ${BASE}$$.c
+    echo "int main() { srand(973); return (10 * rand()) / RAND_MAX; }" >> ${BASE}$$.c
     if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
 	CFLAGS="${CFLAGS} -DHAVE_RAND"
 	HAVE_RANDOM=1
@@ -200,7 +200,7 @@ fi
 
 if [ ${HAVE_RANDOM} -eq 0 ]; then
     echo "#include <stdlib.h>" > ${BASE}$$.c
-    echo "main() { srandom(973); return (10 * random()) / RAND_MAX; }" >> ${BASE}$$.c
+    echo "int main() { srandom(973); return (10 * random()) / RAND_MAX; }" >> ${BASE}$$.c
     if ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL}; then
 	CFLAGS="${CFLAGS} -DHAVE_RANDOM"
 	HAVE_RANDOM=1
@@ -211,7 +211,7 @@ fi
 # check that we have sysmp
 echo "#include <sys/types.h>" > ${BASE}$$.c
 echo "#include <sys/sysmp.h>" >> ${BASE}$$.c
-echo "main() { return (int)sysmp(MP_NPROCS); }" >> ${BASE}$$.c
+echo "int main() { return (int)sysmp(MP_NPROCS); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_SYSMP=1";
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -221,7 +221,7 @@ echo "#include <stdlib.h>" > ${BASE}$$.c
 echo "#include <unistd.h>" >> ${BASE}$$.c
 echo "#include <sys/types.h>" >> ${BASE}$$.c
 echo "#include <sys/processor.h>" >> ${BASE}$$.c
-echo "main() { return bindprocessor(BINDPROCESS, getpid(), 0); }" >> ${BASE}$$.c
+echo "int main() { return bindprocessor(BINDPROCESS, getpid(), 0); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_BINDPROCESSOR=1";
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
@@ -231,16 +231,17 @@ echo "#include <stdlib.h>" > ${BASE}$$.c
 echo "#include <sys/types.h>" >> ${BASE}$$.c
 echo "#include <sys/processor.h>" >> ${BASE}$$.c
 echo "#include <sys/procset.h>" >> ${BASE}$$.c
-echo "main() { return processor(P_PID, P_MYPID, 0, NULL); }" >> ${BASE}$$.c
+echo "int main() { return processor(P_PID, P_MYPID, 0, NULL); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_BINDPROCESSOR=1";
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c
 
 # check that we have sched_setaffinity
-echo "#include <stdlib.h>" > ${BASE}$$.c
+echo "#define _GNU_SOURCE" > ${BASE}$$.c
+echo "#include <stdlib.h>" >> ${BASE}$$.c
 echo "#include <unistd.h>" >> ${BASE}$$.c
 echo "#include <sched.h>" >> ${BASE}$$.c
-echo "main() { unsigned long mask = 1; return sched_setaffinity(0, sizeof(unsigned long), &mask); }" >> ${BASE}$$.c
+echo "int main() { cpu_set_t mask; return sched_setaffinity(0, sizeof(mask), &mask); }" >> ${BASE}$$.c
 ${CC} ${CFLAGS} -o ${BASE}$$ ${BASE}$$.c 1>${NULL} 2>${NULL} \
 	&& CFLAGS="${CFLAGS} -DHAVE_SCHED_SETAFFINITY=1";
 rm -f ${BASE}$$ ${BASE}$$.o ${BASE}$$.c


### PR DESCRIPTION
Changes:
- Add explicit 'int' return type to main() in most test code
- Add #define _GNU_SOURCE for sched_setaffinity detection
- Change sched_setaffinity parameter from 'unsigned long' to 'cpu_set_t'
