### PR TITLE
Replace bitkeeper operations with git ones in Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ GPATH
 GRTAGS
 GTAGS
 
+*.ver
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@
 # doc.lpr	print the documentation
 # doc.x		preview the documentation (needs X, groff, pic, etc)
 # clean		go to the subdirs and $(MAKE) clean
-# get		$(MAKE) sure all files are checked out
 # shar		build a shippable shar archive
 
 SHELL=/bin/sh
@@ -35,22 +34,14 @@ doc.x:
 	cd doc && $(MAKE) x
 
 clobber clean: 
-	for i in doc src results scripts; do \
+	for i in doc src results; do \
 		echo ===== $$i =====; \
 		(cd $$i && $(MAKE) clean); \
 	done
 	/bin/rm -rf bin/*
-	-bk clean 
-
-get: 
-	for i in doc src results scripts; do \
-		echo ===== $$i =====; \
-		(cd $$i && bk get -q); \
-	done
-	@co -q
 
 info: 
-	for i in doc src results scripts; do \
+	for i in doc src results; do \
 		echo ===== $$i =====; \
 		(cd $$i && info); \
 	done
@@ -58,16 +49,11 @@ info:
 release: scripts/mkrelease
 	scripts/mkrelease
 
-scripts/mkrelease:
-	cd scripts && co mkrelease
-
 # XXX - . must be named lmbench for this to work
 shar:
 	$(MAKE) clean
-	co -q Makefile
-	$(MAKE) get
 	cd .. && \
-	find lmbench -type f -print  | egrep -v 'noship|RCS' > /tmp/FILES
-	cd .. && shar -S -a -n lmbench1.0 -L 50K < /tmp/FILES 
+	find lmbench -type f -print | egrep -v 'noship|\.git' > /tmp/FILES
+	cd .. && shar -S -a -n lmbench1.0 -L 50K < /tmp/FILES
 
 FRC:

--- a/SCCS/s.ChangeSet
+++ b/SCCS/s.ChangeSet
@@ -1,2 +1,0 @@
-# a dummy file to update ver
-# ver 3.0 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -84,23 +84,5 @@ install: $(MAN)
 		done; \
 	done
 
-get: $(ALL)
-
-edit:
-	get -e -s $(ALL)
-
-$(MAN):
-	get -s $(MAN)
-
-$(PIC):
-	get -s $(PIC)
-
-$(DESC):
-	get -s $(DESC)
-
-$(USENIX):
-	get -s $(USENIX)
-
 clean:
-	-bk clean 
 	/bin/rm -f *.PS XXX bw.pic memrd_bcopy_comp.pic references.i

--- a/results/Makefile
+++ b/results/Makefile
@@ -309,11 +309,8 @@ bw.8up: bargraphs.1st
 		echo .bp; \
 	done | sed '$$d' | $(PS8UP)
 
-get:	# nothing to do
-
 clean:
 	/bin/rm -f PS/* GIF/* HTML/* tmp/* summary.roff
-	-bk clean
 
 dirs:
 	@if [ ! -d tmp ]; then mkdir tmp; fi

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,8 +1,0 @@
-# Makefile for lmbench scripts subdir.
-#$Id: Makefile 1.3 00/01/31 16:29:28-08:00 lm@lm.bitmover.com $
-
-get:
-	get -s 
-
-clean:
-	-bk clean

--- a/scripts/mkrelease
+++ b/scripts/mkrelease
@@ -5,7 +5,6 @@
 # XXX - does not check for checked out files.
 
 make -s clean
-make -s get
 VERS=`egrep 'MAJOR|MINOR' src/version.h | awk '{print $3}'` 
 set `echo $VERS`
 if [ $2 -lt 0 ] 
@@ -13,11 +12,8 @@ then	VERS=`echo $1$2 | sed s/-/alpha/`
 else	VERS=`echo $VERS |sed 's/ /./'`
 fi
 D=lmbench-$VERS
-mkdir $D $D/results
-cp -rp SCCS doc hbench-REBUTTAL lmbench-HOWTO scripts src $D
-cp -rp results/SCCS $D/results
-(cd $D && make -s get)
-/bin/rm -rf $D/SCCS $D/*/SCCS
+git clone . $D
+/bin/rm -rf $D/.git
 tar czvf $D.tgz $D
 /bin/rm -rf $D
 make -s clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -165,55 +165,41 @@ debug:
 assembler:
 	@env CFLAGS=-O MAKE="$(MAKE)" MAKEFLAGS="$(MAKEFLAGS)" CC="${CC}" OS="${OS}" ../scripts/build asm
 
-bk.ver: ../SCCS/s.ChangeSet
-	rm -f bk.ver
-	-echo `bk prs -hr+ -d'$$if(:SYMBOL:){:SYMBOL: }:UTC:' ../ChangeSet;` > bk.ver
-	touch bk.ver
+git.ver:
+	rm -f git.ver
+	@if git rev-parse --git-dir > /dev/null 2>&1; then \
+		git describe --tags --always --dirty 2>/dev/null > git.ver || echo "3.0-a9" > git.ver; \
+	else \
+		echo "3.0-a9" > git.ver; \
+	fi
 
-dist: bk.ver
-	@if [ "X`cd ..; bk sfiles -c`" != "X" ]; then \
+dist: git.ver
+	@cd ..; \
+	if ! git diff-index --quiet HEAD; then \
 		echo "modified files!"; \
 		false; \
-	 fi
-	@if [ "X`cd ..; bk pending`" != "X" ]; then \
-		echo "pending changes!"; \
-		false; \
-	 fi
+	fi
 	cd ..; \
 		SRCDIR=`pwd`; \
 		DIR=`basename $${SRCDIR}`; \
-		VERSION=`cat src/bk.ver| awk '{print $$1;}' | sed -e 's/Version-//g'`; \
+		VERSION=`cat src/git.ver`; \
 		cd ..; \
-		bk clone $${DIR} /tmp/lmbench-$${VERSION}; \
+		git clone $${DIR} /tmp/lmbench-$${VERSION}; \
 		cd /tmp/lmbench-$${VERSION}; \
-		bk sfiles | xargs touch; \
-		sleep 5; \
-		bk get -s; \
-		for d in doc results scripts src; do \
-			cd $$d; bk get -s; cd ..; \
-		done; \
-		bk sfiles -U -g | xargs touch; \
+		/bin/rm -rf .git; \
 		cd src; \
-		make bk.ver; \
+		make git.ver; \
 		cd /tmp; \
 		tar czf $${SRCDIR}/../lmbench-$${VERSION}.tgz \
 			lmbench-$${VERSION}; \
 		rm -rf /tmp/lmbench-$${VERSION};
 
-get $(SRCS):
-	-get -s $(SRCS)
-
-edit get-e:
-	get -e -s $(SRCS)
-
 clean:
 	/bin/rm -f ../bin/*/CONFIG ../bin/*/*.[oas]
 	/bin/rm -f *.[oas]
-	-bk clean
 
 clobber:
 	/bin/rm -rf ../bin* SHAR
-	-bk clean
 
 shar:
 	cd ../.. && shar lmbench/Results/Makefile $(SAMPLES) lmbench/scripts/* lmbench/src/Makefile lmbench/src/*.[ch] > lmbench/SHAR
@@ -225,12 +211,12 @@ testmake: $(SRCS) $(UTILS) # used by scripts/make to test gmake
 	@true
 
 .PHONY: lmbench results rerun hardware os install all Wall debug \
-	install install-target dist get edit get-e clean clobber \
-	share depend testmake
+	install install-target dist clean clobber shar \
+	depend testmake
 
-$O/lmbench : ../scripts/lmbench bk.ver
+$O/lmbench : ../scripts/lmbench git.ver
 	rm -f $O/lmbench
-	sed -e "s/<version>/`cat bk.ver`/g" < ../scripts/lmbench > $O/lmbench
+	sed -e "s/<version>/`cat git.ver`/g" < ../scripts/lmbench > $O/lmbench
 	chmod +x $O/lmbench
 
 $O/lmbench.a: $(LIBOBJS)
@@ -256,9 +242,6 @@ $O/lib_sched.o : lib_sched.c $(INCS)
 	$(COMPILE) -c lib_sched.c -o $O/lib_sched.o
 $O/getopt.o : getopt.c $(INCS)
 	$(COMPILE) -c getopt.c -o $O/getopt.o
-
-$(UTILS) :
-	-cd ../scripts; make get
 
 # Do not remove the next line, $(MAKE) depend needs it
 # MAKEDEPEND follows


### PR DESCRIPTION
Git instead of bitkeeper is used to manage the source code repo now.