### PR TITLE
scripts/os: fall back to uname-derived OS when gnu-os returns empty

### DIFF
--- a/scripts/os
+++ b/scripts/os
@@ -11,10 +11,14 @@ then	OS=bloat-os
     SYSTEM=`uname -s | sed -e 's/ //g' | sed -e 's?/?-?g'`
     OS="${MACHINE}-${SYSTEM}"
     if [ -f ../scripts/gnu-os ]
-    then	OS=`../scripts/gnu-os | sed s/unknown-//`
+    then
+	NEW_OS=`../scripts/gnu-os 2>/dev/null | sed s/unknown-//`
+	[ -n "$NEW_OS" ] && OS="$NEW_OS"
     fi
     if [ -f ../../scripts/gnu-os ]
-    then	OS=`../../scripts/gnu-os | sed s/unknown-//`
+    then
+	NEW_OS=`../../scripts/gnu-os 2>/dev/null | sed s/unknown-//`
+	[ -n "$NEW_OS" ] && OS="$NEW_OS"
     fi
 fi
 echo $OS


### PR DESCRIPTION
gnu-os (config.guess) does not recognize RISC-V Linux, so it exits 1 and prints nothing to stdout.  The previous code unconditionally assigned its output to OS, clobbering the uname-derived fallback with an empty string.  Only adopt the gnu-os result when it is non-empty.