### PR TITLE
scripts/gnu-os: add riscv Linux cases from upstream config.guess

### DIFF
--- a/scripts/gnu-os
+++ b/scripts/gnu-os
@@ -926,6 +926,9 @@ EOF
     aarch64:Linux:*:*)
 	echo aarch64-unknown-linux-gnu
 	exit 0 ;;
+    riscv32:Linux:*:* | riscv32be:Linux:*:* | riscv64:Linux:*:* | riscv64be:Linux:*:*)
+	echo ${UNAME_MACHINE}-unknown-linux-gnu
+	exit 0 ;;
     i*86:Linux:*:*)
 	# The BFD linker knows what the default object file format is, so
 	# first see if it will tell us. cd to the root directory to prevent


### PR DESCRIPTION
Picked from upstream GNU config.guess (2026-05-17):

  riscv32:Linux:*:* | riscv32be:Linux:*:* | riscv64:Linux:*:* | riscv64be:Linux:*:*)

Upstream: https://git.savannah.gnu.org/cgit/config.git